### PR TITLE
Disable auto prepare

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -108,7 +108,6 @@ Resources:
       FoundationModel: !Sub 'arn:aws:bedrock:${AWS::Region}:${AWS::AccountId}:inference-profile/jp.anthropic.claude-sonnet-4-5-20250929-v1:0'
       Description: Meal planning assistant for Japanese recipes
       IdleSessionTTLInSeconds: 600
-      AutoPrepare: true
       Instruction: |
         You are a helpful meal planning assistant that helps users create balanced Japanese meal plans.
 
@@ -411,9 +410,7 @@ Resources:
     Properties:
       AgentId: !GetAtt KondateAgent.AgentId
       AgentAliasName: production
-      Description: Production alias pointing to auto-prepared DRAFT version
-      RoutingConfiguration:
-        - AgentVersion: DRAFT
+      Description: Production alias with inference profile support
 
   # ==================== Amazon Q Developer / Chatbot ====================
   DeveloperQSlackChannel:


### PR DESCRIPTION
This AWS::Bedrock::AgentAlias resource is in a UPDATE_FAILED state.

Resource handler returned message: "The attribute routingConfiguration in AgentAlias is invalid. DRAFT must not be associated with this alias. Retry the request with a valid attribute. (Service: BedrockAgent, Status Code: 400, Request ID: 9bd6c521-4aa4-475f-97de-63fa2b0e8c07) (SDK Attempt Count: 1)" (RequestToken: f9885423-8e24-f235-ceed-57029938abff, HandlerErrorCode: InvalidRequest)